### PR TITLE
Mention that the class needs to be included too for the provider to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,13 @@ where you wish to manage the quota with this module.
 
 ## Usage
 
+Include the class to ensure the required package(s) are installed, then use the `quota` resource type to specify your rule(s).
+
 Example:
 ```ruby
+
+class { '::quota': }
+
 quota { 'username': 
   name             => 'username',
   ensure           => 'present',


### PR DESCRIPTION
Adds including the quota class to the usage examples to prevent bug reports like #4.